### PR TITLE
Fixed issues with selectAll/None for all option types

### DIFF
--- a/src/nlForm.select.js
+++ b/src/nlForm.select.js
@@ -194,6 +194,41 @@ angular.module('vr.directives.nlForm.select',[])
 			return value;
         }
 
+		// given an option (label, object, value, etc) retrieve its label
+		function getLabelFromOption(option) {
+			var label = option;
+
+			switch($scope.optionType) {
+				case ARRAY_OF_LABELS:
+					// the option is the value so don't do anything
+					break;
+				case OBJECT_OF_VALUES:
+					angular.forEach($scope.options,function(val, lbl) {
+						if(option == val) {
+							label = lbl;
+						}
+					});
+					break;
+				case ARRAY_OF_OBJECTS:
+					// find the option with the given label
+					angular.forEach($scope.options,function(opt) {
+						if(opt.value == option.value) {
+							label = opt.label;
+						}
+					});
+					break;
+				case OBJECT_OF_OBJECTS:
+					angular.forEach($scope.options,function(val, lbl) {
+						if(option == val) {
+							label = lbl;
+						}
+					});
+					break;
+			}
+
+			return label;
+        }
+		
         // check to make sure all the values are in the list of options
 		function checkValue() {
 			if($scope.multiple) {
@@ -233,8 +268,9 @@ angular.module('vr.directives.nlForm.select',[])
          */
         $scope.selectAll = function(){
             angular.forEach($scope.options, function(option){
-                if(!$scope.isSelected(option)){
-                    $scope.select(option);
+				var label = getLabelFromOption(option);
+                if(!$scope.isSelected(label)){
+                    $scope.select(label);
                 }
                 $scope.close();
             });
@@ -245,8 +281,9 @@ angular.module('vr.directives.nlForm.select',[])
          */
         $scope.selectNone = function(){
             angular.forEach($scope.options, function(option){
-                if($scope.isSelected(option)){
-                    $scope.select(option);
+				var label = getLabelFromOption(option);
+                if($scope.isSelected(label)){
+                    $scope.select(label);
                 }
                 $scope.close();
             });


### PR DESCRIPTION
selectAll()/selectNone() methods only worked for ARRAY_OF_LABELS. Fixed so that it
works for all 4 types of option definitions. (Maybe some refactoring is needed as the method parameter name 'option' seems to sometimes represent a label or a value.)
